### PR TITLE
Change Checkbox to Switch for Textual 0.11.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,4 +96,4 @@ repos:
     - bleak
     - bluetooth-numbers
     - rich
-    - textual
+    - textual>=0.11.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ bleak>=0.19.0
 bluetooth-numbers>=1.0.0,<2.0
 furo
 sphinx>=3.2.1
-textual>=0.6.0
+textual>=0.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     bluetooth-numbers>=1.0.0,<2.0
     bleak>=0.19.0
     importlib-metadata; python_version<"3.8"
-    textual>=0.6.0
+    textual>=0.11.0
 
 
 [options.packages.find]
@@ -76,7 +76,7 @@ testing =
     pytest
     pytest-cov
     setuptools
-    textual[dev]>=0.6.0
+    textual[dev]>=0.11.0
 
 [options.entry_points]
 console_scripts =

--- a/src/humble_explorer/app.css
+++ b/src/humble_explorer/app.css
@@ -8,7 +8,7 @@
     width: auto;
 }
 
-Checkbox {
+Switch {
     height: auto;
     width: auto;
 }

--- a/src/humble_explorer/app.py
+++ b/src/humble_explorer/app.py
@@ -10,7 +10,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from textual.app import App, ComposeResult
 from textual.reactive import reactive
-from textual.widgets import Checkbox, DataTable, Footer, Header, Input
+from textual.widgets import DataTable, Footer, Header, Input, Switch
 
 if system() == "Linux":
     from bleak.assigned_numbers import AdvertisementDataType
@@ -135,12 +135,12 @@ class BLEScannerApp(App[None]):
                 type should be shown and ``False`` if not.
         """
         return {
-            "local_name": self.query_one("#local_name", Checkbox).value,
-            "rssi": self.query_one("#rssi", Checkbox).value,
-            "tx_power": self.query_one("#tx_power", Checkbox).value,
-            "manufacturer_data": self.query_one("#manufacturer_data", Checkbox).value,
-            "service_data": self.query_one("#service_data", Checkbox).value,
-            "service_uuids": self.query_one("#service_uuids", Checkbox).value,
+            "local_name": self.query_one("#local_name", Switch).value,
+            "rssi": self.query_one("#rssi", Switch).value,
+            "tx_power": self.query_one("#tx_power", Switch).value,
+            "manufacturer_data": self.query_one("#manufacturer_data", Switch).value,
+            "service_data": self.query_one("#service_data", Switch).value,
+            "service_uuids": self.query_one("#service_uuids", Switch).value,
         }
 
     async def on_advertisement(
@@ -179,15 +179,15 @@ class BLEScannerApp(App[None]):
         self.scanner = BleakScanner(**self.scanner_kwargs)
         await self.start_scan()
 
-    def on_checkbox_changed(self, message: Checkbox.Changed) -> None:
-        """React when the checkbox is ticked or unticked.
+    def on_switch_changed(self, message: Switch.Changed) -> None:
+        """React when the switch is ticked or unticked.
 
         Show or hide advertisement data depending on the state of
-        the checkboxes.
+        the switches.
 
         Args:
-            message (textual.widgets.Checkbox.Changed): The message with the changed
-                checkbox.
+            message (textual.widgets.Switch.Changed): The message with the changed
+                switch.
         """
         if "view" in message.input.classes:
             self.recreate_table()
@@ -229,7 +229,7 @@ class BLEScannerApp(App[None]):
 
     def scroll_if_autoscroll(self) -> None:
         """Scroll to the end if autoscroll is enabled."""
-        if self.query_one("#autoscroll", Checkbox).value:
+        if self.query_one("#autoscroll", Switch).value:
             self.query_one(DataTable).scroll_end(animate=False)
 
     def add_advertisement_to_table(

--- a/src/humble_explorer/widgets.py
+++ b/src/humble_explorer/widgets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal
-from textual.widgets import Checkbox, Input, Static
+from textual.widgets import Input, Static, Switch
 
 __author__ = "Koen Vervloesem"
 __copyright__ = "Koen Vervloesem"
@@ -40,42 +40,42 @@ class SettingsWidget(Static):
         self.display = False
 
     def compose(self) -> ComposeResult:
-        """Show checkboxes."""
+        """Show switches."""
         yield Static("[b]Show data types[/b]\n")
         yield Horizontal(
             Static("Local name       ", classes="label"),
-            Checkbox(value=True, id="local_name", classes="view"),
+            Switch(value=True, id="local_name", classes="view"),
             classes="container",
         )
         yield Horizontal(
             Static("RSSI             ", classes="label"),
-            Checkbox(value=True, id="rssi", classes="view"),
+            Switch(value=True, id="rssi", classes="view"),
             classes="container",
         )
         yield Horizontal(
             Static("TX power         ", classes="label"),
-            Checkbox(value=True, id="tx_power", classes="view"),
+            Switch(value=True, id="tx_power", classes="view"),
             classes="container",
         )
         yield Horizontal(
             Static("Manufacturer data", classes="label"),
-            Checkbox(value=True, id="manufacturer_data", classes="view"),
+            Switch(value=True, id="manufacturer_data", classes="view"),
             classes="container",
         )
         yield Horizontal(
             Static("Service data     ", classes="label"),
-            Checkbox(value=True, id="service_data", classes="view"),
+            Switch(value=True, id="service_data", classes="view"),
             classes="container",
         )
         yield Horizontal(
             Static("Service UUIDs    ", classes="label"),
-            Checkbox(value=True, id="service_uuids", classes="view"),
+            Switch(value=True, id="service_uuids", classes="view"),
             classes="container",
         )
         yield Static("\n[b]Other settings[/b]\n")
         yield Horizontal(
             Static("Auto-scroll      ", classes="label"),
-            Checkbox(value=True, id="autoscroll", classes="view"),
+            Switch(value=True, id="autoscroll", classes="view"),
             classes="container",
         )
 


### PR DESCRIPTION
`Checkbox` has been renamed to `Switch` in [Textual 0.11.0](https://github.com/Textualize/textual/releases/tag/v0.11.0).